### PR TITLE
Wrapped path variable in FirefoxCookiePath to get cookies from different local profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ npm i firefox-cookie
 
 ```javascript
 
+// Search for the "default" profile in Firefox implicitly https://support.mozilla.org/gl/questions/1264072
 const FirefoxCookie = require('firefox-cookie');
 const FFCookie = new FirefoxCookie();
+
+// Search for the "default-release" new profile in Firefox explicitly (or any other profile you give as parameter)
+const FirefoxCookie = require('firefox-cookie');
+const FFCookie = new FirefoxCookie("default-release");
 
 // Reading cookie
 const cookie = await FFCookie.getCookie('arshad.com');

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function Firefox(path) {
   this.tableName = CONSTANTS['TABLE_NAME'];
   this.cookies = require(CONSTANTS['MODEL_PATH']);
   this.fields =  SelectFields.get(this.cookies);
-  this.sqliteCrud = new SQLiteCrud(path || FirefoxCookiePath());
+  this.sqliteCrud = new SQLiteCrud(FirefoxCookiePath(path) || FirefoxCookiePath());
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firefox-cookie",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Node Firefox Cookie Manager",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This way if you know the profile name you need to get the Cookies from it will connect and query the correct SQLite DB related to that profile.
As explained [here](https://support.mozilla.org/gl/questions/1264072) the new default profile name has changed from `default` to `default-release` and this can fix the problems with this module.